### PR TITLE
feat: add youtube-music theme check

### DIFF
--- a/modules/programs/media/youtube-music/default.nix
+++ b/modules/programs/media/youtube-music/default.nix
@@ -151,12 +151,14 @@
 
       # Fetch the theme
       home.activation.fetchYoutubeTheme = lib.mkAfter ''
-        export PATH=${pkgs.curl}/bin:$PATH
-        THEME_DIR="$HOME/.config/YouTube Music/themes"
-        THEME_FILE="$THEME_DIR/catppuccin-mocha.css"
-        mkdir -p "$THEME_DIR"
-        curl -sSfL "https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/macchiato.css" -o "$THEME_FILE"
-      '';
+       if ! [ -f "$HOME/.config/YouTube Music/themes/catppuccin-mocha.css" ]; then
+         export PATH=${pkgs.curl}/bin:$PATH
+         THEME_DIR="$HOME/.config/YouTube Music/themes"
+         THEME_FILE="$THEME_DIR/catppuccin-mocha.css"
+         mkdir -p "$THEME_DIR"
+         curl -sSfL "https://raw.githubusercontent.com/catppuccin/youtubemusic/main/src/macchiato.css" -o "$THEME_FILE"
+       fi
+     '';
 
       # make the config writable (may cause home-manager conflicts)
       # home.activation.makeYoutubeMusicConfigWritable = lib.mkAfter ''


### PR DESCRIPTION
when booting up the system, home-manager was throwing an error because it couldn't run curl.

